### PR TITLE
Fixed windows related bug around URL path normalization

### DIFF
--- a/gglsbl/protocol.py
+++ b/gglsbl/protocol.py
@@ -5,7 +5,7 @@ import struct
 import time
 from StringIO import StringIO
 import random
-import os
+import posixpath
 import re
 import hashlib
 import socket
@@ -334,7 +334,7 @@ class URL(object):
         if not path:
             path = '/'
         has_trailing_slash = (path[-1] == '/')
-        path = os.path.normpath(path).replace('//', '/')
+        path = posixpath.normpath(path).replace('//', '/')
         if has_trailing_slash and path[-1] != '/':
             path = path + '/'
         user = url_parts.username


### PR DESCRIPTION
On a windows box, os.path uses windows path separators, which does not
match URL path separators. The class posixpath is OS agnostic.
