### PR TITLE
Add an additional list that contains malware urls

### DIFF
--- a/gglsbl/protocol.py
+++ b/gglsbl/protocol.py
@@ -22,7 +22,8 @@ class BaseProtocolClient(object):
             "base_url": "https://safebrowsing.google.com/safebrowsing/",
             "lists": [
                 "goog-malware-shavar",
-                "googpub-phish-shavar"
+                "googpub-phish-shavar",
+                "goog-unwanted-shavar"
             ],
             "url_args": {
                 "key": api_key,


### PR DESCRIPTION
I don't know when this was added to the documentation, but missing this list has been causing false negatives in the API. Here's a link to the docs where it shows this list: https://developers.google.com/safe-browsing/developers_guide_v3#ListContents