### PR TITLE
Adds list_name to primary key

### DIFF
--- a/gglsbl/storage.py
+++ b/gglsbl/storage.py
@@ -89,7 +89,7 @@ class SqliteStorage(StorageBase):
             list_name character varying(127) NOT NULL,
             downloaded_at timestamp DEFAULT current_timestamp,
             expires_at timestamp without time zone NOT NULL,
-            PRIMARY KEY (value)
+            PRIMARY KEY (value, list_name)
             )"""
         )
 


### PR DESCRIPTION
Fixes issue with URLs on multiple lists.

`sqlite3.IntegrityError: UNIQUE constraint failed: full_hash.value`

I had this problem with the URL "http://malware.testing.google.test/testing/malware/", because it's found on two lists: "goog-malware-shavar" and "googpub-phish-shavar".

The fix provided does not migrate old databases, so someone might want to propose an alternate solution or improve on this one.