### PR TITLE
Fix key error in fh_response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ target/
 # SQLite cache DB
 *.sqlite
 
+# Pycharm project files and venv
+.idea
+venv
+
+# ctags
+tags

--- a/gglsbl/client.py
+++ b/gglsbl/client.py
@@ -104,27 +104,21 @@ class SafeBrowsingList(object):
 
         # update negative cache for each hash prefix
         # store full hash (insert or update) with positive cache bumped up
-        try:
-            for m in fh_response['matches']:
-                threat_list = ThreatList(m['threatType'], m['platformType'], m['threatEntryType'])
-                hash_value = b64decode(m['threat']['hash'])
-                cache_duration = int(m['cacheDuration'].rstrip('s'))
-                malware_threat_type = None
-                for metadata in m['threatEntryMetadata'].get('entries', []):
-                    k = b64decode(metadata['key'])
-                    v = b64decode(metadata['value'])
-                    if k == 'malware_threat_type':
-                        malware_threat_type = v
-                self.storage.store_full_hash(threat_list, hash_value, cache_duration, malware_threat_type)
-        except KeyError:
-            pass
+        for m in fh_response.get('matches', []):
+            threat_list = ThreatList(m['threatType'], m['platformType'], m['threatEntryType'])
+            hash_value = b64decode(m['threat']['hash'])
+            cache_duration = int(m['cacheDuration'].rstrip('s'))
+            malware_threat_type = None
+            for metadata in m['threatEntryMetadata'].get('entries', []):
+                k = b64decode(metadata['key'])
+                v = b64decode(metadata['value'])
+                if k == 'malware_threat_type':
+                    malware_threat_type = v
+            self.storage.store_full_hash(threat_list, hash_value, cache_duration, malware_threat_type)
 
-        try:
-            negative_cache_duration = int(fh_response['negativeCacheDuration'].rstrip('s'))
-            for prefix_value in hash_prefixes:
-                self.storage.update_hash_prefix_expiration(prefix_value, negative_cache_duration)
-        except KeyError:
-            pass
+        negative_cache_duration = int(fh_response['negativeCacheDuration'].rstrip('s'))
+        for prefix_value in hash_prefixes:
+            self.storage.update_hash_prefix_expiration(prefix_value, negative_cache_duration)
 
     def lookup_url(self, url):
         """Look up specified URL in Safe Browsing threat lists."""


### PR DESCRIPTION
While using [gglsbl-rest](https://github.com/mlsecproject/gglsbl-rest) I got key errors in
[gglsbl](https://github.com/afilipovich/gglsbl) due to an answer that does not contain 'matches'
in the google repsonse dict `fh_response`.

As poined out in [Safe Browsing lookup API (v4)](https://developers.google.com/safe-browsing/v4/lookup-api) the answer can be empty:

> **Response body**
>
> The response body includes the match information (the list names and the URLs found on those lists, the metadata, if available, and the cache durations). For more details, see the threatMatches.find response body and the explanations that follow the code example.
> 
> **Note:** If there are no matches (that is, if none of the URLs specified in the request are found on any of the lists specified in a request), the HTTP POST response simply returns an empty object in the response body.

So it seems necessary to put a try-except block for accessing the dict.